### PR TITLE
Fix EF Core context configuration

### DIFF
--- a/src/ProductService/ProductService.Data/ProductDbContext.cs
+++ b/src/ProductService/ProductService.Data/ProductDbContext.cs
@@ -8,8 +8,13 @@ internal class ProductDbContext(DbContextOptions<ProductDbContext> options) : Db
 {
     public DbSet<Product> Products { get; set; }
 
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) =>
-        optionsBuilder.UseNpgsql();
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        if (!optionsBuilder.IsConfigured)
+        {
+            optionsBuilder.UseNpgsql();
+        }
+    }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) => modelBuilder.ApplyConfigurationsFromAssembly(typeof(ProductConfiguration).Assembly);
 }

--- a/src/UserService/UserService.Data/UserDbContext.cs
+++ b/src/UserService/UserService.Data/UserDbContext.cs
@@ -8,8 +8,13 @@ public class UserDbContext : IdentityDbContext<User>
 {
     public UserDbContext(DbContextOptions<UserDbContext> options) : base(options) { }
 
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) =>
-        optionsBuilder
-            .UseOpenIddict()
-            .UseNpgsql();
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        if (!optionsBuilder.IsConfigured)
+        {
+            optionsBuilder.UseNpgsql();
+        }
+
+        optionsBuilder.UseOpenIddict();
+    }
 }


### PR DESCRIPTION
## Summary
- avoid overwriting EF Core connection strings in ProductService and UserService contexts

## Testing
- `dotnet build src/e-shop.slnx -c Release` *(fails: `dotnet` not found)*
- `npm test` *(fails: missing npm script)*

------
https://chatgpt.com/codex/tasks/task_e_68408a555e30832f8686647cc61ef77b